### PR TITLE
Refresh expires and docs private key

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -18,11 +18,11 @@ You can not change option after close initialize context manger!
 
 ## Secrets
 
-| key          | description                           | type   | default |
-|:-------------|:--------------------------------------|:-------|:--------|
-| `secret_key` | encode/decode key for `HS*` algorithm | string | `None`  |
-| `public_key` | decode key for `RS*` algorithm        | string | `None`  |
-| `secret_key` | encode key for `RS*` algorithm        | string | `None`  |
+| key           | description                           | type   | default |
+|:--------------|:--------------------------------------|:-------|:--------|
+| `secret_key`  | encode/decode key for `HS*` algorithm | string | `None`  |
+| `public_key`  | decode key for `RS*` algorithm        | string | `None`  |
+| `private_key` | encode key for `RS*` algorithm        | string | `None`  |
 
 ## Default values for reserved claims
 

--- a/sanic_jwt_extended/jwt_manager.py
+++ b/sanic_jwt_extended/jwt_manager.py
@@ -213,7 +213,7 @@ class JWT:
                 payload[f"{private_claim_prefix}.{k}"] = v
 
         if expires_delta is None:
-            expires_delta = cls.config.access_token_expires
+            expires_delta = cls.config.refresh_token_expires
 
         refresh_token = cls._encode_jwt("refresh", payload, expires_delta)
 


### PR DESCRIPTION
I use your package, thanks.
Here, my first contribution, I will next time fix audience when config.default_aud is set. If it is set, the PyJWT decode function will throw error because we don't supply which value it should have.

In this codebase: https://github.com/NovemberOscar/Sanic-JWT-Extended/blob/01da577ab57910e28312edfa2452d914c6482585/sanic_jwt_extended/tokens.py#L130
In PyJWT codebase: https://github.com/jpadilla/pyjwt/blob/09f2e20c6621b531be37392a514d8805f9804723/jwt/api_jwt.py#L203-L206