### PR TITLE
Feature/multirole rbac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 # IDEs
 .idea/
+.vscode/

--- a/sanic_jwt_extended/decorators.py
+++ b/sanic_jwt_extended/decorators.py
@@ -155,7 +155,7 @@ def jwt_required(
 
             if fresh_required and not token_obj.fresh:
                 raise FreshTokenRequiredError("Only fresh access tokens are allowed")
-            
+
             if isinstance(token_obj.role, str):
                 if allow and token_obj.role not in allow:
                     raise AccessDeniedError("You are not allowed to access here")
@@ -169,7 +169,7 @@ def jwt_required(
 
                 if deny and set(token_obj.role).intersection(set(deny)):
                     raise AccessDeniedError("You are not allowed to access here")
-            
+
             if JWT.config.use_blacklist and await JWT.blacklist.is_blacklisted(
                 token_obj
             ):

--- a/sanic_jwt_extended/decorators.py
+++ b/sanic_jwt_extended/decorators.py
@@ -155,13 +155,21 @@ def jwt_required(
 
             if fresh_required and not token_obj.fresh:
                 raise FreshTokenRequiredError("Only fresh access tokens are allowed")
+            
+            if isinstance(token_obj.role, str):
+                if allow and token_obj.role not in allow:
+                    raise AccessDeniedError("You are not allowed to access here")
 
-            if allow and not set(token_obj.role).intersection(set(allow)):
-                raise AccessDeniedError("You are not allowed to access here")
+                if deny and token_obj.role in deny:
+                    raise AccessDeniedError("You are not allowed to access here")
 
-            if deny and set(token_obj.role).intersection(set(deny)):
-                raise AccessDeniedError("You are not allowed to access here")
+            if isinstance(token_obj.role, list):
+                if allow and not set(token_obj.role).intersection(set(allow)):
+                    raise AccessDeniedError("You are not allowed to access here")
 
+                if deny and set(token_obj.role).intersection(set(deny)):
+                    raise AccessDeniedError("You are not allowed to access here")
+            
             if JWT.config.use_blacklist and await JWT.blacklist.is_blacklisted(
                 token_obj
             ):

--- a/sanic_jwt_extended/decorators.py
+++ b/sanic_jwt_extended/decorators.py
@@ -156,10 +156,10 @@ def jwt_required(
             if fresh_required and not token_obj.fresh:
                 raise FreshTokenRequiredError("Only fresh access tokens are allowed")
 
-            if allow and token_obj.role not in allow:
+            if allow and not set(token_obj.role).intersection(set(allow)):
                 raise AccessDeniedError("You are not allowed to access here")
 
-            if deny and token_obj.role in deny:
+            if deny and set(token_obj.role).intersection(set(deny)):
                 raise AccessDeniedError("You are not allowed to access here")
 
             if JWT.config.use_blacklist and await JWT.blacklist.is_blacklisted(


### PR DESCRIPTION
I had to made this change to support RBAC with multiple roles. This is under such scenarios, where we want a user to have more than one role. Made up random use case: A user can be an ADMIN for say 2 out of 5 sections of the application. Or, if we want to implement RBAC for a Suite of Applications.

At the moment, when creating an access token, it already accepts a list of roles. 

For eg, **create_access_token**(...., **role**=['ADMIN', 'MANAGER']) totally works. 
And we can successfully retrieve the list of roles from token.role

The only drawback here is, when using **jwt_required** with **allow** or **deny** parameters, this list of roles are not handled, it is only handled when the role is a string. This PR is an attempt to handle that. 

Currently the functionality is that, if at least one role in token.role is in allow or deny list. It allows or denies. 